### PR TITLE
Change pypi package name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,4 +243,4 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python -m twine upload --verbose dist/*.whl # Updated path
+          python -m twine upload --non-interactive --verbose dist/*.whl # Updated path

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "scope"
+name = "vnscope"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,13 +4,10 @@ build-backend = "maturin"
 
 [project]
 name = "vnscope"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.5.0,<2.0.0"]
 build-backend = "maturin"
 
 [project]
-name = "scope"
+name = "vnscope"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -9,7 +9,7 @@ sys.path.append(str(parent_dir))
 
 # Try to import the package - handle potential import errors gracefully
 try:
-    from vnstock import market, Monitor, Datastore
+    from vnscope import market, Monitor, Datastore
     IMPORTS_SUCCEEDED = True
 except ImportError as e:
     print(f"Import error: {e}")

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -9,18 +9,18 @@ sys.path.append(str(parent_dir))
 
 # Try to import the package - handle potential import errors gracefully
 try:
-    from scope import market, Monitor, Datastore
+    from vnstock import market, Monitor, Datastore
     IMPORTS_SUCCEEDED = True
 except ImportError as e:
     print(f"Import error: {e}")
     IMPORTS_SUCCEEDED = False
 
 # Skip all tests if imports failed
-pytestmark = pytest.mark.skipif(not IMPORTS_SUCCEEDED, reason="Failed to import scope package")
+pytestmark = pytest.mark.skipif(not IMPORTS_SUCCEEDED, reason="Failed to import vnscope package")
 
 def test_package_imports():
     """Test that the package can be imported."""
-    assert IMPORTS_SUCCEEDED, "Failed to import scope package"
+    assert IMPORTS_SUCCEEDED, "Failed to import vnscope package"
 
 @pytest.mark.skipif(not IMPORTS_SUCCEEDED, reason="Scope package not available")
 def test_market_function_exists():
@@ -111,5 +111,5 @@ def test_datastore_save_and_load():
         pytest.skip(f"Datastore save/load test failed: {str(e)}")
 
 if __name__ == "__main__":
-    # This allows running the tests directly with python tests/test_scope.py
+    # This allows running the tests directly with python tests/test_vnscope.py
     pytest.main(["-xvs", __file__])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the project and library name to "vnscope" in backend configurations.
  - Raised the minimum Python version requirement to 3.11.
  - Enhanced the release publishing workflow for smoother automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->