### PR TITLE
Fix issue call metrics return 404 and remove grafana-agent metrics

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -309,8 +309,8 @@ async fn main() -> std::io::Result<()> {
     // @NOTE: spawn new http server
     let server = HttpServer::new(move || {
         App::new()
-            .wrap(Logger::default())
             .wrap(prometheus.clone())
+            .wrap(Logger::default())
             .route("/health", get().to(health))
             .route("/api/v1/config/synchronize", put().to(synchronize))
             .app_data(Data::new(portal.clone()))

--- a/grafana-agent.yaml
+++ b/grafana-agent.yaml
@@ -8,14 +8,11 @@ metrics:
   configs:
     - name: app
       scrape_configs:
-        - job_name: rust_app
+        - job_name: application
           static_configs:
             - targets: ['localhost:8000'] # Port of Rust application
               labels:
                 instance: rust-server
-        - job_name: agent
-          static_configs:
-            - targets: ['localhost:12345'] # Port of Grafana Agent
       remote_write:
         - url: https://prometheus-prod-18-prod-ap-southeast-0.grafana.net/api/prom/push
           basic_auth:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated monitoring configuration: changed a job name and removed an unused scrape job from the metrics configuration.
- **Refactor**
  - Adjusted the order of monitoring and logging middleware in the server to improve request processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->