### PR TITLE
Fix wrong type of new 3rd API's response

### DIFF
--- a/pkgs/backend/src/actors/mod.rs
+++ b/pkgs/backend/src/actors/mod.rs
@@ -146,7 +146,7 @@ pub struct CWInfo {
     pub underlying: String,
 
     #[serde(rename = "exercisePrice")]
-    pub exercise_price: u64,
+    pub exercise_price: f64,
 
     #[serde(rename = "exerciseRatio")]
     pub exercise_ratio: String,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `exercise_price` field to support decimal values instead of whole numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->