### PR TITLE
Remove outdated APIs

### DIFF
--- a/pkgs/backend/sdk/vnscope/__init__.py
+++ b/pkgs/backend/sdk/vnscope/__init__.py
@@ -1,6 +1,5 @@
 from .core import configure
 from .core import filter, order, profile, history, price, market
-from .core import cw, sectors, industry
 
 from .core import crypto
 from .core import Monitor, Datastore, Evolution
@@ -19,9 +18,6 @@ __all__ = [
     "history",
     "price",
     "market",
-    "cw",
-    "sectors",
-    "industry",
     "configure",
     "Symbols",
     "Evolution",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed `cw`, `sectors`, and `industry` from the public API. These are no longer accessible from package imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->