### PR TITLE
Remove outdated API `crypto`

### DIFF
--- a/pkgs/backend/sdk/vnscope/__init__.py
+++ b/pkgs/backend/sdk/vnscope/__init__.py
@@ -1,7 +1,6 @@
 from .core import configure
 from .core import filter, order, profile, history, price, market
 
-from .core import crypto
 from .core import Monitor, Datastore, Evolution
 from .util import align_and_concat, group_files_by_symbol
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed public API access to crypto functionality from the vnscope module. Applications importing crypto directly from vnscope will need to update their import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->