### PR TITLE
Setup FACEBOOK_OUTGOING_SECRET to reply messages to users

### DIFF
--- a/pkgs/backend/src/api/chat/facebook/mod.rs
+++ b/pkgs/backend/src/api/chat/facebook/mod.rs
@@ -16,7 +16,7 @@ pub async fn get_username(appdata: &Data<Arc<AppState>>, sender_id: &String) -> 
     let client = HttpClient::default();
     let url = format!(
         "https://graph.facebook.com/{}?fields=name&access_token={}",
-        sender_id, appdata.chat.fb.page_access_token,
+        sender_id, appdata.chat.fb.outgoing_secret,
     );
     let response = client
         .get(&url)
@@ -43,7 +43,7 @@ pub async fn send_message(
     let client = HttpClient::default();
     let url = format!(
         "https://graph.facebook.com/v24.0/me/messages?access_token={}",
-        appstate.chat.fb.page_access_token,
+        appstate.chat.fb.outgoing_secret,
     );
     let body = json!({
         "recipient": {

--- a/pkgs/backend/src/api/chat/mod.rs
+++ b/pkgs/backend/src/api/chat/mod.rs
@@ -12,7 +12,6 @@ pub struct Slack {
 
 pub struct Facebook {
     pub webhook_access_token: String,
-    pub page_access_token: String,
     pub incomming_secret: String,
     pub outgoing_secret: String,
 }

--- a/pkgs/backend/src/api/mod.rs
+++ b/pkgs/backend/src/api/mod.rs
@@ -242,32 +242,28 @@ impl AppState {
             fb: chat::Facebook {
                 webhook_access_token: get_secret_from_infisical(
                     &infisical_client,
-                    "FACEBOOK_TOKEN",
-                    "/",
-                )
-                .await?,
-                page_access_token: get_secret_from_infisical(
-                    &infisical_client,
-                    "FACEBOOK_TOKEN",
-                    "/",
+                    "FACEBOOK_WEBHOOK_VERIFY_TOKEN",
+                    "/facebook/",
                 )
                 .await?,
                 incomming_secret: get_secret_from_infisical(
                     &infisical_client,
                     "FACEBOOK_INCOMMING_SECRET",
-                    "/",
+                    "/facebook/",
                 )
                 .await?,
                 outgoing_secret: get_secret_from_infisical(
                     &infisical_client,
                     "FACEBOOK_OUTGOING_SECRET",
-                    "/",
+                    "/facebook/",
                 )
                 .await?,
             },
             slack: chat::Slack {
-                token: get_secret_from_infisical(&infisical_client, "SLACK_BOT_TOKEN", "/").await?,
-                channel: get_secret_from_infisical(&infisical_client, "SLACK_CHANNEL", "/").await?,
+                token: get_secret_from_infisical(&infisical_client, "SLACK_BOT_TOKEN", "/slack/")
+                    .await?,
+                channel: get_secret_from_infisical(&infisical_client, "SLACK_CHANNEL", "/slack/")
+                    .await?,
             },
         });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized Facebook and Slack configuration: consolidated token/secret handling into distinct webhook, incoming, and outgoing secrets and moved retrievals to a dedicated configuration path.
  * No changes to request flows or error handling; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->