### PR TITLE
Setup proxy to redirect traffic to wordpress

### DIFF
--- a/conf/nginx/http.conf
+++ b/conf/nginx/http.conf
@@ -77,12 +77,53 @@ http {
     ##
     # Logging
     ##
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
+    log_format main escape=json
+    '{'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"http_referer":"$http_referer",'
+        '"http_user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for",'
+        '"request_time":$request_time,'
+        '"upstream_response_time":$upstream_response_time,'
+        '"upstream_addr":"$upstream_addr",'
+        '"host":"$host",'
+        '"scheme":"$scheme"'
+    '}';
+
+    log_format detail escape=json
+    '{'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"real_ip":"$http_x_forwarded_for",'
+        '"host":"$host",'
+        '"request_id":"$request_id",'
+        '"request":"$request",'
+        '"method":"$request_method",'
+        '"uri":"$request_uri",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_response_time":$upstream_response_time,'
+        '"upstream_addr":"$upstream_addr",'
+        '"upstream_status":$upstream_status,'
+        '"http_referrer":"$http_referer",'
+        '"http_user_agent":"$http_user_agent",'
+        '"http_x_forwarded_proto":"$http_x_forwarded_proto",'
+        '"http_x_forwarded_host":"$http_x_forwarded_host",'
+        '"ssl_protocol":"$ssl_protocol",'
+        '"ssl_cipher":"$ssl_cipher",'
+        '"cf_ray":"$http_cf_ray",'
+        '"pipe":"$pipe",'
+        '"bytes_sent":$bytes_sent'
+    '}';
 
     # log access ra stdout
-    access_log /dev/stdout main;
+    access_log /dev/stdout %%NGINX_LOG%%;
 
     # log error ra stderr
     error_log /dev/stderr warn;

--- a/conf/nginx/www.conf
+++ b/conf/nginx/www.conf
@@ -45,10 +45,27 @@ server {
         return 405;
     }
 
+    # WordPress admin/login/api → skip cache
+    location ~* /(wp-admin|wp-login\.php|wp-json/|xmlrpc\.php) {
+        proxy_pass %%WOOCOMMERCE_PROTOCOL%%://%%WOOCOMMERCE_SERVER%%;
+        proxy_set_header Host %%WOOCOMMERCE_SERVER%%;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 60s;
+        proxy_cache_bypass 1;
+        proxy_no_cache 1;
+        proxy_ssl_server_name on;
+        proxy_ssl_verify off;
+    }
+
     # General PHP / WooCommerce
     location ~ \.php$ {
         proxy_pass %%WOOCOMMERCE_PROTOCOL%%://%%WOOCOMMERCE_SERVER%%;
-        proxy_set_header Host $host;
+        proxy_set_header Host %%WOOCOMMERCE_SERVER%%;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -58,44 +75,12 @@ server {
         proxy_no_cache $skip_cache $cache_bypass;
         proxy_cache_valid 200 301 302 60m;
         proxy_cache_use_stale error timeout invalid_header updating;
+        proxy_connect_timeout 30s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 60s;
+        proxy_ssl_verify off;
+        proxy_ssl_server_name on;
         add_header X-Cache-Status $upstream_cache_status;
-    }
-
-    # WordPress admin/login/api → skip cache
-    location ~* /(wp-admin|wp-login\.php) {
-        proxy_pass %%WOOCOMMERCE_PROTOCOL%%://%%WOOCOMMERCE_SERVER%%;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass 1;
-        proxy_no_cache 1;
-    }
-
-    location ~ ^/wp-json/ {
-        allow 127.0.0.1;
-        deny all;
-
-        proxy_pass %%WOOCOMMERCE_PROTOCOL%%://%%WOOCOMMERCE_SERVER%%;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass 1;
-        proxy_no_cache 1;
-    }
-
-    location = /xmlrpc.php {
-        allow 127.0.0.1;
-        deny all;
-
-        proxy_pass %%WOOCOMMERCE_PROTOCOL%%://%%WOOCOMMERCE_SERVER%%;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_cache_bypass 1;
-        proxy_no_cache 1;
     }
 
     # Healthcheck

--- a/pkgs/backend/Cargo.toml
+++ b/pkgs/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backend"
-version = "1.0.50"
+version = "1.0.51"
 edition = "2021"
 
 [[bin]]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,6 +72,10 @@ function boot() {
     sed -i '/HTTP_X_FORWARDED_PORT/d' ${NGINX_DIR}/http.d/default.conf
     HTTP_PROTOCOL="http"
   fi
+
+  # Setup log
+  sed -i "s/%%NGINX_LOG%%/$NGINX_LOG/g" ${NGINX_DIR}/nginx.conf
+
   # Setup S3 backend
   sed -i "s#%%CDN_ENDPOINT%%#$CDN_ENDPOINT#g" ${NGINX_DIR}/http.d/default.conf
   sed -i "s#%%CDN_BUCKET%%#$CDN_BUCKET#g" ${NGINX_DIR}/http.d/default.conf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated WordPress admin/login/REST/XML‑RPC routing into a unified bypass with updated headers, per-path timeouts, and extended cache/no‑cache controls including X-Cache-Status.
  * Restored proxied PHP handling with caching enabled, per-path timeouts, SSL server name enabled and backend SSL verification disabled where applicable.
  * Switched access logging to structured JSON formats and inject the log destination at startup.
  * Bumped backend package version (1.0.50 → 1.0.51).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->